### PR TITLE
Fix new minecart with block breaking furnace minecart display

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/BlockMinecartEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/BlockMinecartEntity.java
@@ -32,34 +32,30 @@ import org.geysermc.connector.entity.type.EntityType;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.world.block.BlockTranslator;
 
-public class MinecartEntity extends Entity {
+public class BlockMinecartEntity extends MinecartEntity {
 
-    public MinecartEntity(long entityId, long geyserId, EntityType entityType, Vector3f position, Vector3f motion, Vector3f rotation) {
-        super(entityId, geyserId, entityType, position.add(0d, entityType.getOffset(), 0d), motion, rotation);
+    public BlockMinecartEntity(long entityId, long geyserId, EntityType entityType, Vector3f position, Vector3f motion, Vector3f rotation) {
+        super(entityId, geyserId, entityType, position, motion, rotation);
     }
 
     @Override
     public void updateBedrockMetadata(EntityMetadata entityMetadata, GeyserSession session) {
-
-        if (entityMetadata.getId() == 7) {
-            metadata.put(EntityData.HEALTH, entityMetadata.getValue());
+        // Custom block
+        if (entityMetadata.getId() == 10) {
+            metadata.put(EntityData.DISPLAY_ITEM, BlockTranslator.getBedrockBlockId((int) entityMetadata.getValue()));
         }
 
-        // Direction in which the minecart is shaking
-        if (entityMetadata.getId() == 8) {
-            metadata.put(EntityData.HURT_DIRECTION, entityMetadata.getValue());
+        // Custom block offset
+        if (entityMetadata.getId() == 11) {
+            metadata.put(EntityData.DISPLAY_OFFSET, entityMetadata.getValue());
         }
 
-        // Power in Java, time in Bedrock
-        if (entityMetadata.getId() == 9) {
-            metadata.put(EntityData.HURT_TIME, Math.min((int) (float) entityMetadata.getValue(), 15));
+        // If the custom block should be enabled
+        if (entityMetadata.getId() == 12) {
+            // Needs a byte based off of Java's boolean
+            metadata.put(EntityData.HAS_DISPLAY, (byte) ((boolean) entityMetadata.getValue() ? 1 : 0));
         }
 
         super.updateBedrockMetadata(entityMetadata, session);
-    }
-
-    @Override
-    public void moveAbsolute(GeyserSession session, Vector3f position, Vector3f rotation, boolean isOnGround, boolean teleported) {
-        super.moveAbsolute(session, position.add(0d, this.entityType.getOffset(), 0d), rotation, isOnGround, teleported);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/entity/type/EntityType.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/type/EntityType.java
@@ -119,7 +119,7 @@ public enum EntityType {
     SNOWBALL(ThrowableEntity.class, 81, 0.25f),
     THROWN_EGG(ThrowableEntity.class, 82, 0.25f, 0.25f, 0.25f, 0f, "minecraft:egg"),
     PAINTING(PaintingEntity.class, 83, 0f),
-    MINECART(MinecartEntity.class, 84, 0.7f, 0.98f, 0.98f, 0.35f),
+    MINECART(BlockMinecartEntity.class, 84, 0.7f, 0.98f, 0.98f, 0.35f),
     FIREBALL(ItemedFireballEntity.class, 85, 1.0f),
     THROWN_POTION(ThrowableEntity.class, 86, 0.25f, 0.25f, 0.25f, 0f, "minecraft:splash_potion"),
     THROWN_ENDERPEARL(ThrowableEntity.class, 87, 0.25f, 0.25f, 0.25f, 0f, "minecraft:ender_pearl"),


### PR DESCRIPTION
This moves the DISPLAY_ITEM part of the minecart entity to a seperate class and not the base entity to prevent issues with things such as furnace minecarts not displaying properly