### PR TITLE
Implement workaround for out of order StartGame packet

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -510,7 +510,13 @@ public class GeyserSession implements CommandSender {
         startGamePacket.setItemEntries(ItemRegistry.ITEMS);
         startGamePacket.setVanillaVersion("*");
         // startGamePacket.setMovementServerAuthoritative(true);
-        upstream.sendPacket(startGamePacket);
+        upstream.sendPacketImmediately(startGamePacket);
+
+        // Sleep this thread long enough for the StartGame packet to be processed.
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException ignored) {
+        }
     }
 
     public boolean confirmTeleport(Vector3d position) {


### PR DESCRIPTION
Randomly the StartGame packet will end up sent after the packets that are supposed come after it. This workaround will force a 500ms delay after the packet to ensure it has the best chance of coming first.